### PR TITLE
fix the syntax for irc nicks

### DIFF
--- a/lib/parser_grammar.js
+++ b/lib/parser_grammar.js
@@ -19,7 +19,7 @@ with (com.deadpixi.kouprey) {
     Grammar.Message   = $([Optional(Prefix), Command, $(Some(Params), "params"), Crlf], "message");
     Grammar.Prefix    = [":", Or(Server, Person), Space];
     Grammar.Server    = [$(/^[-\[\]|_\w\.]+/, "servername"), Not(/^(?:!|@)[-~\[\]|_\w\.]+/)];
-    Grammar.Person    = $([$(/^[-\[\]|_\w\.]+/, "nick"), Optional(["!", $(/^[-~\[\]|_=\w\.]+/, "user")]), Optional(["@", $(/^[-\[\]|_\/\w\.:]+/, "host")])], "person");
+    Grammar.Person    = $([$(/^[-\[\]|_\w`\\{}\^]+/, "nick"), Optional(["!", $(/^[-~\[\]|_=\w\.]+/, "user")]), Optional(["@", $(/^[-\[\]|_\/\w\.:]+/, "host")])], "person");
     Grammar.Space     = /^[ ]+/;
     Grammar.Command   = $(/^[a-zA-Z]+|\d{3}/, "command");
     Grammar.Params    = [Space, Optional(Or([":", $(/^[^\0\r\n]*/, "trailing")], $(/^[^:][^ \0\r\n]*/, "middle")))];


### PR DESCRIPTION
removed . (dot) and added '\', '{', '}', '^' and '`'

ps. NO U
