### PR TITLE
If quit() causes a network error IRC tries to emit an 'error' event

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -117,7 +117,9 @@ function IRC (options) {
         line = buffer[i], message = buildMessage(Parser.parse(line + "\r\n"))
         if (!internal.connected)
           do_connect.call(this) // We're "connected" once we receive data
-        emitter.emit(message.command.toLowerCase(), message)
+        if (message.command.toLowerCase() !== "error") {
+          emitter.emit(message.command.toLowerCase(), message)
+        }
       }
     }
     catch (e) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -247,7 +247,6 @@ function IRC (options) {
    *     irc_instance.addListener('PING', pingListener); // Listens for the PING message from server
   **/
   this.addListener = function (event, hollaback) {
-      console.log("IRC:addListener: ", event);
     var bound = hollaback.bind(this)
 
     if (!internal.listener_cache[event]) {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -123,6 +123,7 @@ function IRC (options) {
     catch (e) {
       if (DEBUG)
         sys.puts("[ERROR] Parsing '" + line + "'")
+        throw e;
     }
   }
   
@@ -246,20 +247,14 @@ function IRC (options) {
    *     irc_instance.addListener('PING', pingListener); // Listens for the PING message from server
   **/
   this.addListener = function (event, hollaback) {
-    var bound;
-
-    if (internal.listener_cache[event] &&
-      internal.listener_cache[event][hollaback]) {
-      emitter.removeListener(event, internal.listener_cache[event][hollaback])
-    }
-
-    bound = hollaback.bind(this)
+      console.log("IRC:addListener: ", event);
+    var bound = hollaback.bind(this)
 
     if (!internal.listener_cache[event]) {
-      internal.listener_cache[event] = {}
+      internal.listener_cache[event] = []
     }
 
-    internal.listener_cache[event][hollaback] = bound
+    internal.listener_cache[event].push(bound);
     emitter.addListener(event, bound)
     return this
   }
@@ -276,14 +271,23 @@ function IRC (options) {
    *     irc_instance.removeListener('PING', pingListener); // Stops listening for the PING message from server
   **/
   this.removeListener = function (event, hollaback) {
-    if (internal.listener_cache[event] &&
-      internal.listener_cache[event][hollaback]) {
-      emitter.removeListener(event, internal.listener_cache[event][hollaback])
-      delete internal.listener_cache[event][hollaback]
+    if (internal.listener_cache[event]) {
+      var eventCache = internal.listener_cache[event]
+      for (var i = 0; i < eventCache.length; i++) {
+        if (eventCache[i] === hollaback) {
+          // If last element.
+          if (i+1 === eventCache.length) {
+            eventCache.pop();
+          } else {
+            // Replace index with last element.
+            eventCache[i] = eventCache.pop();
+          }
+          emitter.removeListener(event, eventCache[i]);
+        }
+      }
     }
-
-    return this
-  }
+    return this;
+  };
   
   /**
    * IRC#listenOnce(event, listener) -> null


### PR DESCRIPTION
Attached is a fix. I'm not sure whether this is the real issue, or if an error event should not be sent to parseMessage in the first place, or if it should even be retrieved by the stream listeners...
