### PR TITLE
net.Stream error handling

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -96,6 +96,11 @@ function IRC( options ) {
     stream.end()
     emitter.emit( 'disconnected' )
   }
+
+  // Handle stream errors
+  function handleStreamError(exception) {
+    emitter.emit('error', exception);
+  }
   
   // Parse incoming messages
   function parseMessage( data ) { var buffer, last, message, command, i
@@ -164,20 +169,26 @@ function IRC( options ) {
         stream.removeAllListeners()
         stream = null
       }
-      stream = net.createConnection( this.options.port, this.options.server )
+
+      stream = new net.Stream()
       stream.setEncoding( this.options.encoding )
       stream.setTimeout( 0 )
 
+      // Network error (ECONNREFUSED, ECONNRESET,...)
+      stream.addListener( 'error', handleStreamError.bind( this ) )
+
       // Receive data
       stream.addListener( 'data', parseMessage.bind( this ) )
-      
+
       // Timeout
       stream.addListener( 'timeout', do_disconnect.bind( this ) )
-      
+
       // End
       stream.addListener( 'end', do_disconnect.bind( this ) )
+
+      stream.connect(this.options.port, this.options.server)
     }
-      
+
     // Holla
     if ( typeof hollaback === 'function' )
       this.listenOnce( 'connected', hollaback )


### PR DESCRIPTION
Switched to net.connect() to work around an issue with net.createConnection that sometimes throws connection errors before being able to register the listeners.

I've added a handler that emits an 'error' event and passes the exception to the callback, to be used by the caller.
