### PR TITLE
Network errors handling

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -167,7 +167,10 @@ function IRC( options ) {
       stream.setTimeout( 0 )
 
       // Forward network errors
-      stream.addListener( 'error', function(e) { emitter.emit('network_error', e) } )
+      stream.addListener( 'error', function(e) {
+                                    emitter.emit('error', e)
+                                    emitter.emit('error:network', e)
+                                  })
 
       // Receive data
       stream.addListener( 'data', parseMessage.bind( this ) )

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -166,6 +166,9 @@ function IRC( options ) {
       stream.setEncoding( this.options.encoding )
       stream.setTimeout( 0 )
 
+      // Forward network errors
+      stream.addListener( 'error', function(e) { emitter.emit('network_error', e) } )
+
       // Receive data
       stream.addListener( 'data', parseMessage.bind( this ) )
 


### PR DESCRIPTION
Hi!

Sorry to bother you with this again, but I noticed you removed the stream error listener and shifted that to the parseMessage method. However this will not handle network errors, and that way, the only solution would be to catch 'uncaughtException' at the process level, which is not ideal most of the time :)

I've added an 'error' listener that will just emit a 'network_error' so it's not mixed with the IRC errors, that way one can just listen to that and have the details in the exception passed as parameter, so we can handle it the way we want at the caller level.

Would that be a good solution for you?

Regards,
Renaud
