### PR TITLE
listenOnce fixes

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -288,17 +288,22 @@ function IRC( options ) {
    * 
    *     irc_instance.listenOnce( 'PING', pingListener ); // Listens for the *next* PING message from server, then unregisters itself
   **/
-  this.listenOnce = function( event, hollaback ) {
+  this.listenOnce = function( event, hollaback, listenFor, listenParam ) {
     // Store reference and wrap
     var listenId = single_listener_count
-    single_listener_count++
+    single_listener_count++;
     internal.single_listener_cache[ listenId ] = function( hollaback, message ) {
       // Call function
-      hollaback.call( this, message )
-      
+      if( message && listenFor )
+      {
+	if( message.params[ listenParam ] && message.params[ listenParam ] == listenFor )
+	  hollaback.call( this, message );
+      }
+      else
+	hollaback.call( this, message );
       // Unregister self
       setTimeout( function() {
-        if(internal.single_listener_cache[ listenId ])
+        if( internal.single_listener_cache[ listenId ] && ( !listenFor || listenFor==message.params[ listenParam ] ) )
         {
           emitter.removeListener( event, internal.single_listener_cache[ listenId ] )
           delete internal.single_listener_cache[ listenId ]
@@ -518,7 +523,7 @@ function IRC( options ) {
     // Register event for names query
     this.listenOnce( '353', function( message ) {
       hollaback.call( this, message.params[2], $w( message.params.slice( -1 ) ) )
-    })
+    }, channel, 2)
     return this.raw( 'NAMES' + param( channel ) )
   }
   

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -517,7 +517,7 @@ function IRC( options ) {
     // 4.2.5
     // Register event for names query
     this.listenOnce( '353', function( message ) {
-      hollaback.call( this, message.params[1], $w( message.params.slice( -1 ) ) )
+      hollaback.call( this, message.params[2], $w( message.params.slice( -1 ) ) )
     })
     return this.raw( 'NAMES' + param( channel ) )
   }

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -288,19 +288,19 @@ function IRC( options ) {
   **/
   this.listenOnce = function( event, hollaback ) {
     // Store reference and wrap
-    internal.single_listener_cache[hollaback] = function( hollaback, message ) {
+    internal.single_listener_cache[hollaback+"_"+event] = function( hollaback, message ) {
       // Call function
       hollaback.call( this, message )
       
       // Unregister self
       setTimeout( function() {
-        emitter.removeListener( event, internal.single_listener_cache[hollaback] )
-        delete internal.single_listener_cache[hollaback]
+        emitter.removeListener( event, internal.single_listener_cache[hollaback+"_"+event] )
+        delete internal.single_listener_cache[hollaback+"_"+event]
       }, 0 )
     }.bind( this, hollaback )
     
     // Listen
-    emitter.addListener( event, internal.single_listener_cache[hollaback] )
+    emitter.addListener( event, internal.single_listener_cache[hollaback+"_"+event] )
   }
   
   /* ------------------------------ Convenience Methods ------------------------------ */

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -59,10 +59,12 @@ function IRC( options ) {
         , privmsg_queue: []
         , listener_cache: {}
         , single_listener_cache: {}
+        , single_listener_count: 0
         , cache: {}
         , locks: {}
         }
     , emitter  = new process.EventEmitter()
+    , single_listener_count = 0
     , stream
 
   ( this.options = options || {} ).__proto__ = IRC.options
@@ -288,19 +290,25 @@ function IRC( options ) {
   **/
   this.listenOnce = function( event, hollaback ) {
     // Store reference and wrap
-    internal.single_listener_cache[hollaback+"_"+event] = function( hollaback, message ) {
+    var listenId = single_listener_count
+    single_listener_count++
+    internal.single_listener_cache[hollaback+"_"+listenId] = function( hollaback, message ) {
       // Call function
       hollaback.call( this, message )
       
       // Unregister self
       setTimeout( function() {
-        emitter.removeListener( event, internal.single_listener_cache[hollaback+"_"+event] )
-        delete internal.single_listener_cache[hollaback+"_"+event]
+        if(internal.single_listener_cache[hollaback+"_"+listenId])
+        {
+          emitter.removeListener( event, internal.single_listener_cache[hollaback+"_"+listenId] )
+          delete internal.single_listener_cache[hollaback+"_"+listenId]
+        }
       }, 0 )
     }.bind( this, hollaback )
     
     // Listen
-    emitter.addListener( event, internal.single_listener_cache[hollaback+"_"+event] )
+    emitter.addListener( event, internal.single_listener_cache[hollaback+"_"+internal.single_listener_count] )
+    internal.single_listener_count++;
   }
   
   /* ------------------------------ Convenience Methods ------------------------------ */

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -292,23 +292,22 @@ function IRC( options ) {
     // Store reference and wrap
     var listenId = single_listener_count
     single_listener_count++
-    internal.single_listener_cache[hollaback+"_"+listenId] = function( hollaback, message ) {
+    internal.single_listener_cache[ listenId ] = function( hollaback, message ) {
       // Call function
       hollaback.call( this, message )
       
       // Unregister self
       setTimeout( function() {
-        if(internal.single_listener_cache[hollaback+"_"+listenId])
+        if(internal.single_listener_cache[ listenId ])
         {
-          emitter.removeListener( event, internal.single_listener_cache[hollaback+"_"+listenId] )
-          delete internal.single_listener_cache[hollaback+"_"+listenId]
+          emitter.removeListener( event, internal.single_listener_cache[ listenId ] )
+          delete internal.single_listener_cache[ listenId ]
         }
       }, 0 )
     }.bind( this, hollaback )
     
     // Listen
-    emitter.addListener( event, internal.single_listener_cache[hollaback+"_"+internal.single_listener_count] )
-    internal.single_listener_count++;
+    emitter.addListener( event, internal.single_listener_cache[ listenId ] )
   }
   
   /* ------------------------------ Convenience Methods ------------------------------ */


### PR DESCRIPTION
Hi!

There were some situations where listenOnce calls would crash (for example, when doing something like irc.names() inside a connect function), by adding a unique id (single_listener_count) to the internal storage hashmap it now works.

Also added a check to make sure it didn't attempt to remove a listener it had already removed, this would happen if there were multiple listenOnce's happening on the same event (In my case, calling .names inside a for loop on a channel array)

Hope you find them useful!

Thanks
James
