### PR TITLE
Client sends login command to server directly after commit, and do not wait for server to say something

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -163,9 +163,9 @@ function IRC( options ) {
       stream.setEncoding( this.options.encoding )
       stream.setTimeout( 0 )
 
-			// Login directly after the connection is established
-			stream.on('connect', do_connect.bind(this))
-			
+      // Login directly after the connection is established
+      stream.on('connect', do_connect.bind(this))
+      
       // Forward network errors
       stream.on( 'error', function( er ) {
         emitter.emit( 'error', er )

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -120,10 +120,6 @@ function IRC( options ) {
           throw err
       }
 
-      // We're "connected" once we receive data
-      if ( !internal.connected )
-        do_connect.call( this )
-
       // Set internal nick
       if ( command == '001' )
         internal.nick = message.params[0]
@@ -167,6 +163,9 @@ function IRC( options ) {
       stream.setEncoding( this.options.encoding )
       stream.setTimeout( 0 )
 
+			// Login directly after the connection is established
+			stream.on('connect', do_connect.bind(this))
+			
       // Forward network errors
       stream.on( 'error', function( er ) {
         emitter.emit( 'error', er )


### PR DESCRIPTION
Client sends login command to server directly after commit, and no longer waits for server to say something first. Another fix for gf3/IRC-js#38, this time there is no options for this behaviour.

I tested this against ngIRCD and irc.freenode.net.
