### PR TITLE
Emit 'connected' event later in the connection

### DIFF
--- a/lib/irc.js
+++ b/lib/irc.js
@@ -93,9 +93,15 @@ function doConnect () {
       sendPrivmsg.call( this, m.receiver, m.message )
   }.bind( this ), 200 )
 
-  this._internal.emitter.once( '376', function() {
+  var on_connected = (function () {
     this._internal.emitter.emit( 'connected' )
-  }.bind( this ) )
+  }).bind( this )
+
+  this._internal.emitter.once( '376', on_connected )
+
+  setTimeout( function() {
+    this._internal.emitter.removeListener( '376', on_connected )
+  }, 10000 )
 }
 
 function doDisconnect () {

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -93,7 +93,9 @@ function doConnect () {
       sendPrivmsg.call( this, m.receiver, m.message )
   }.bind( this ), 200 )
 
-  this._internal.emitter.emit( 'connected' )
+  this._internal.emitter.once( '376', function() {
+    this._internal.emitter.emit( 'connected' )
+  }.bind( this ) )
 }
 
 function doDisconnect () {


### PR DESCRIPTION
Emitting 'connected' as soon as the actual connection is established isn't good. Any event handlers that, for example, join a channel, will not succeed because USER/NICK hasn't been sent. Instead, should wait until after the MOTD is received (which is sent after NICK/USER combo on the IRCd's I tried) to fire those.
