### PR TITLE
correctly listen for network error events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,5 @@ test-objects:
 test-parser:
 	@export IRCJS_TEST=1;\
 	node --harmony $(MOCHA) --reporter spec --require should spec/lib/parser.spec.js;\
+
+test: test-irc test-logger test-objects test-parser

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -244,7 +244,7 @@ Client.prototype.connect = function(callback) {
   sock.addListener(NODE.SOCKET.EVENT.DATA, onData.bind(this));
   sock.addListener(NODE.SOCKET.EVENT.TIMEOUT, this.disconnect.bind(this));
   // Forward network errors
-  sock.addListener(NODE.SOCKET.ERROR, this.notify.bind(this, EVENT.ERROR));
+  sock.addListener(NODE.SOCKET.EVENT.ERROR, this.notify.bind(this, EVENT.ERROR));
 
   if (1 === arguments.length) { // Do all servers send a 001 ?
     const client  = this;

--- a/spec/lib/irc.spec.js
+++ b/spec/lib/irc.spec.js
@@ -427,5 +427,18 @@ describe("irc", function() {
         "NOTICE AUTH 11\r\nNOTICE AUTH 12\r\nNOTICE AUTH 13\r\nNOTICE AUTH 14\r\nNOTICE AUTH 15\r\n" +
         "NOTICE AUTH 16\r\nNOTICE AUTH 17\r\nNOTICE AUTH 18\r\nNOTICE AUTH 19\r\nNOTICE AUTH 20\r\n");
     });
+
+    bit("should forward errors to client", function(done) {
+      const bot = this;
+      let got = 0;
+      bot.match(cs.EVENT.ERROR, function() {
+        got++;
+        done();
+      });
+      bot.socket.emit("error");
+      setTimeout(function() {
+        got.should.equal(1);
+      }, 0);
+    });
   });
 });

--- a/spec/lib/irc.spec.js
+++ b/spec/lib/irc.spec.js
@@ -185,10 +185,9 @@ describe("irc", function() {
     describe("channels", function() {
       bit("should let you add channels by name", function(done) {
         const bot  = this;
-        const chan = this.join("#addchanname", function(ch) {
+        const chan = this.join("#addchanname", function() {
           bot.channels.has(chan.id).should.equal(true);
-          bot.channels.get(ch.id).should.equal(chan);
-          ch.should.equal(chan);
+          bot.channels.get(chan.id).should.equal(chan);
           done();
         });
         server.recite(f(":%s!~a@b.c JOIN %s\r\n", this.user.nick, chan));
@@ -202,7 +201,7 @@ describe("irc", function() {
         this.join(chan, function(ch) {
           bot.channels.has(irc.id("#addchanobj")).should.equal(true);
           bot.channels.get(irc.id("#addchanobj")).should.equal(chan);
-          bot.channels.get(ch.id).should.equal(chan);
+          bot.channels.get(chan.id).should.equal(chan);
           done();
         });
         server.recite(f(":%s!~a@b.c JOIN %s\r\n", this.user.nick, chan));
@@ -330,12 +329,11 @@ describe("irc", function() {
         const nick = "unique";
         const bot  = this;
         bot.join("#channelone")
-        bot.join("#channeltwo",
-          function(ch) {
-            ch.people.get(irc.id(nick)).should.equal(
-              bot.channels.get(irc.id("#channelone")).people.get(irc.id(nick)));
-            done();
-          });
+        const ch = bot.join("#channeltwo", function() {
+          ch.people.get(irc.id(nick)).should.equal(
+            bot.channels.get(irc.id("#channelone")).people.get(irc.id(nick)));
+          done();
+        });
         server.recite(f(":%s@wee JOIN %s\r\n", this.user.nick, "#channelone"));
         server.recite(f(":%s@wee JOIN %s\r\n", this.user.nick, "#channeltwo"));
         server.recite(f(":card.freenode.net 353 %s @ %s :%s nlogax\r\n",

--- a/spec/lib/objects.spec.js
+++ b/spec/lib/objects.spec.js
@@ -261,7 +261,7 @@ describe("objects", function() {
         const chan = irc.channel("#callbackz");
         const bot = this;
         chan.client = bot;
-        chan.join(function(ch) {
+        const ch = chan.join(function() {
           chan.should.equal(ch);
           ch.people.has(bot.user.id).should.equal(true);
           ch.people.has(irc.id("nlogax")).should.equal(true);
@@ -283,7 +283,7 @@ describe("objects", function() {
         const chan  = irc.channel("#keycallback");
         const key   = "keyback";
         chan.client = this;
-        chan.join(key, function(ch) {
+        const ch = chan.join(key, function() {
           chan.should.equal(ch);
           done();
         });


### PR DESCRIPTION
unit test included.

aaronj1335/IRC-js@0a6b471 tweaks some of the unit tests so they're passing and adds a `test` target to the makefile to match [the readme](https://github.com/gf3/IRC-js/blob/master/README.md#tests). if this commit needs to be excluded, that's fine, but i figured it'd be better to have strictly passing unit tests than wait til the `chan.join` callback thing is fixed.

i'm going to try to [re-add ssl support](https://github.com/gf3/IRC-js/issues/20) if that's cool (or am i missing it somewhere?), so this is just to support that.
