### PR TITLE
enable ssl connections through IRC-js api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,5 @@ test-objects:
 test-parser:
 	@export IRCJS_TEST=1;\
 	node --harmony $(MOCHA) --reporter spec --require should spec/lib/parser.spec.js;\
+
+test: test-irc test-logger test-objects test-parser

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,6 +19,7 @@ const EVENT = {
 const SOCKEVENT = {
   CLOSE: "close",
   CONNECT: "connect",
+  SECURE_CONNECT: "secureConnect",
   DATA: "data",
   DRAIN: "drain",
   END: "end",

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -244,7 +244,7 @@ Client.prototype.connect = function(callback) {
   sock.addListener(NODE.SOCKET.EVENT.DATA, onData.bind(this));
   sock.addListener(NODE.SOCKET.EVENT.TIMEOUT, this.disconnect.bind(this));
   // Forward network errors
-  sock.addListener(NODE.SOCKET.ERROR, this.notify.bind(this, EVENT.ERROR));
+  sock.addListener(NODE.SOCKET.EVENT.ERROR, this.notify.bind(this, EVENT.ERROR));
 
   if (1 === arguments.length) { // Do all servers send a 001 ?
     const client  = this;

--- a/lib/irc.js
+++ b/lib/irc.js
@@ -48,6 +48,7 @@ const CFG_MODE          = "mode";
 const CFG_NICK          = "nick";
 const CFG_PASSWORD      = "password";
 const CFG_PORT          = "port";
+const CFG_SSL           = "ssl";
 const CFG_REALNAME      = "realname";
 const CFG_SERVER        = "server";
 const CFG_USER          = "user";
@@ -71,6 +72,7 @@ defaultConfig[CFG_NICK]           = "ircjsbot";
 defaultConfig[CFG_SERVER]               = {};
 defaultConfig[CFG_SERVER][CFG_ADDRESS]  = "chat.freenode.net";
 defaultConfig[CFG_SERVER][CFG_PORT]     = 6667;
+defaultConfig[CFG_SERVER][CFG_SSL]      = false;
 
 defaultConfig[CFG_USER]               = {};
 defaultConfig[CFG_USER][CFG_REALNAME] = "IRC-JS Bot";
@@ -149,7 +151,7 @@ function Client(conf) {
   this.connectedAt    = new Date(0);
   this.handlers       = new Map();
   this.messageBuffer  = new Buffer(MESSAGE_BUFFER_SIZE);
-  this.server         = new Server(server.get(CFG_ADDRESS), server.get(CFG_PORT));
+  this.server         = new Server(server.get(CFG_ADDRESS), server.get(CFG_PORT), server.get(CFG_SSL));
   this.user           = new Person(config.get(CFG_NICK), null, null);
   this.streamBuffer   = null;
   this.socket         = null;
@@ -237,10 +239,11 @@ Client.prototype.connect = function(callback) {
     log.warn("Already connected at %s", this.connectedAt);
     return this;
   }
-  const sock = this.socket = net.connect(this.server.port, this.server.name);
+  const sock = this.socket = this.server.connect();
   sock.setTimeout(0);
 
   sock.addListener(NODE.SOCKET.EVENT.CONNECT, onConnect.bind(this));
+  sock.addListener(NODE.SOCKET.EVENT.SECURE_CONNECT, onConnect.bind(this));
   sock.addListener(NODE.SOCKET.EVENT.DATA, onData.bind(this));
   sock.addListener(NODE.SOCKET.EVENT.TIMEOUT, this.disconnect.bind(this));
   // Forward network errors

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,9 @@
 
 "use strict";
 
+const net       = require('net');
+const tls       = require('tls');
+
 const constants = require("./constants");
 const format    = require("util").format;
 const util      = require("./util");
@@ -16,15 +19,18 @@ const DEFAULT_PORT  = 6667;
 const serverCache   = new Map();
 
 /** @constructor
- *  @param {string}   name
- *  @param {number=}  port
- *  @property {string} name
- *  @property {number} port
+ *  @param {string}     name
+ *  @param {number=}    port
+ *  @param {bool}       ssl
+ *  @property {string}  name
+ *  @property {number}  port
+ *  @property {bool}    ssl
  */
-function Server(name, port) {
+function Server(name, port, ssl) {
   this.client = null;
   this.name   = name;
   this.port   = port;
+  this.ssl    = ssl;
 }
 
 /** Serialize server into string
@@ -37,6 +43,17 @@ Server.prototype.toString = function() {
 Server.prototype.getVersion = function(callback) {
   this.client.send(message(COMMAND.VERSION, [this.name]));
   return this;
+}
+
+/** Create a socket connection
+ * @return {Socket}
+ */
+Server.prototype.connect = function() {
+  if (this.ssl) {
+    return tls.connect(this.port, this.name, this.ssl);
+  } else {
+    return net.connect(this.port, this.name);
+  }
 }
 
 /** Make a Server object

--- a/spec/lib/irc.spec.js
+++ b/spec/lib/irc.spec.js
@@ -427,5 +427,18 @@ describe("irc", function() {
         "NOTICE AUTH 11\r\nNOTICE AUTH 12\r\nNOTICE AUTH 13\r\nNOTICE AUTH 14\r\nNOTICE AUTH 15\r\n" +
         "NOTICE AUTH 16\r\nNOTICE AUTH 17\r\nNOTICE AUTH 18\r\nNOTICE AUTH 19\r\nNOTICE AUTH 20\r\n");
     });
+
+    bit("should forward errors to client", function(done) {
+      const bot = this;
+      let got = 0;
+      bot.match(cs.EVENT.ERROR, function() {
+        got++;
+        done();
+      });
+      bot.socket.emit("error");
+      setTimeout(function() {
+        got.should.equal(1);
+      }, 0);
+    });
   });
 });

--- a/spec/lib/irc.spec.js
+++ b/spec/lib/irc.spec.js
@@ -185,10 +185,9 @@ describe("irc", function() {
     describe("channels", function() {
       bit("should let you add channels by name", function(done) {
         const bot  = this;
-        const chan = this.join("#addchanname", function(ch) {
+        const chan = this.join("#addchanname", function() {
           bot.channels.has(chan.id).should.equal(true);
-          bot.channels.get(ch.id).should.equal(chan);
-          ch.should.equal(chan);
+          bot.channels.get(chan.id).should.equal(chan);
           done();
         });
         server.recite(f(":%s!~a@b.c JOIN %s\r\n", this.user.nick, chan));
@@ -202,7 +201,7 @@ describe("irc", function() {
         this.join(chan, function(ch) {
           bot.channels.has(irc.id("#addchanobj")).should.equal(true);
           bot.channels.get(irc.id("#addchanobj")).should.equal(chan);
-          bot.channels.get(ch.id).should.equal(chan);
+          bot.channels.get(chan.id).should.equal(chan);
           done();
         });
         server.recite(f(":%s!~a@b.c JOIN %s\r\n", this.user.nick, chan));
@@ -330,12 +329,11 @@ describe("irc", function() {
         const nick = "unique";
         const bot  = this;
         bot.join("#channelone")
-        bot.join("#channeltwo",
-          function(ch) {
-            ch.people.get(irc.id(nick)).should.equal(
-              bot.channels.get(irc.id("#channelone")).people.get(irc.id(nick)));
-            done();
-          });
+        const ch = bot.join("#channeltwo", function() {
+          ch.people.get(irc.id(nick)).should.equal(
+            bot.channels.get(irc.id("#channelone")).people.get(irc.id(nick)));
+          done();
+        });
         server.recite(f(":%s@wee JOIN %s\r\n", this.user.nick, "#channelone"));
         server.recite(f(":%s@wee JOIN %s\r\n", this.user.nick, "#channeltwo"));
         server.recite(f(":card.freenode.net 353 %s @ %s :%s nlogax\r\n",

--- a/spec/lib/objects.spec.js
+++ b/spec/lib/objects.spec.js
@@ -261,7 +261,7 @@ describe("objects", function() {
         const chan = irc.channel("#callbackz");
         const bot = this;
         chan.client = bot;
-        chan.join(function(ch) {
+        const ch = chan.join(function() {
           chan.should.equal(ch);
           ch.people.has(bot.user.id).should.equal(true);
           ch.people.has(irc.id("nlogax")).should.equal(true);
@@ -283,7 +283,7 @@ describe("objects", function() {
         const chan  = irc.channel("#keycallback");
         const key   = "keyback";
         chan.client = this;
-        chan.join(key, function(ch) {
+        const ch = chan.join(key, function() {
           chan.should.equal(ch);
           done();
         });


### PR DESCRIPTION
depends on #68

this allows the user to include an `ssl` hash (or bool) in the server
connection params:

``` js
var irc = require('irc-js');
var bot = irc.connect({
  server: {
    address: 'chat.freenode.net',
    port: 6697,
    ssl: true // could also be: {rejectUnauthorized: false}
  },
  nick: 'aaronj1335'
}, function(bot) {
  // ...
});
```

the value defaults to false, and if it's truthy, it gets passed strait
through to [`tls.connect`](http://nodejs.org/api/tls.html).

a couple thoughts:
- i didn't include a unit test only because i don't know what exactly to
  test, though i'm happy to implement something
- this messes with the server caching. cases where the user wants two
  connections, one ssl and one not ssl to the same server/port will be
  handled incorrectly. i think these are rare enough that it's safe to
  ignore for now though.
